### PR TITLE
MIGRATE-ONEPUB Remove publish_to URL from pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: uipickers
 description: A plugin library that exposes platform specific date, time and picker popups. It uses native iOS 14 style pickers on iOS and corresponding material pickers on other platforms.
 version: 1.1.1
-publish_to: "https://onepub.dev/api/xpupsdavuh/"
+publish_to: none
 
 environment:
   sdk: ">=3.4.0 <4.0.0"


### PR DESCRIPTION
This pull request makes a minor update to the `pubspec.yaml` configuration by disabling publishing to a custom repository. The `publish_to` field is now set to `none`, which prevents accidental publishing of the package.

- Set `publish_to` to `none` in `pubspec.yaml` to disable publishing to a remote repository.